### PR TITLE
Credential add specs and refactor

### DIFF
--- a/interventions_gateway_api.rb
+++ b/interventions_gateway_api.rb
@@ -27,7 +27,7 @@ class InterventionsGatewayApi < Sinatra::Base
     if request.post?
       setup_credentials
       unless valid_credentials
-        halt 401
+        halt 401, 'invalid credentials, please check your token details'
       end
     end
   end

--- a/lib/credential.rb
+++ b/lib/credential.rb
@@ -11,8 +11,8 @@ class Credential
   end
 
   def logged_in?
-    return false unless jwt_payload.present?
-    jwt_payload['login'].present?
+    return false if jwt_payload.empty?
+    jwt_payload.key?('login')
   rescue JWT::ExpiredSignature
     false
   end
@@ -45,7 +45,12 @@ class Credential
   private
 
   def jwt_payload
-    @jwt_payload ||= token ? client.current_user : {}
+    @jwt_payload ||=
+      if token
+        client.current_user
+      else
+        {}
+      end
   end
 
   def client

--- a/spec/interventions_api_gateway_spec.rb
+++ b/spec/interventions_api_gateway_spec.rb
@@ -18,6 +18,7 @@ describe "InterventionsGatewayApi" do
     it "should respond with unauthorized without auth headers" do
       post end_point, json_payload
       expect(last_response).to be_unauthorized
+      expect(last_response.body).to eq("invalid credentials, please check your token details")
     end
 
     context "when token is expired" do

--- a/spec/lib/credential_spec.rb
+++ b/spec/lib/credential_spec.rb
@@ -75,12 +75,34 @@ describe "Credential" do
   end
 
   describe "accessible_project?" do
-    it "should pass with correct roles for token" do
-      pending
+    let(:client_double) do
+      instance_double("Panoptes::Client", panoptes: page_double)
     end
 
-    it "should fail when i have no roles on project" do
-      pending
+    before do
+      allow(Panoptes::Client).to receive(:new).and_return(client_double)
+    end
+
+    context "with correct roles on the project for the supplied token" do
+      let(:response) do
+        {
+          "projects"=> [{"id"=>"1"}]
+        }
+      end
+      let(:page_double) { double(paginate: response) }
+
+      it "should pass" do
+        expect(credential.accessible_project?(1)).to eq(true)
+      end
+    end
+
+    context "with no correct roles on the project for the supplied token" do
+      let(:response) { { "projects"=> [] } }
+      let(:page_double) { double(paginate: response) }
+
+      it "should fail" do
+        expect(credential.accessible_project?(1)).to eq(false)
+      end
     end
   end
 end

--- a/spec/lib/credential_spec.rb
+++ b/spec/lib/credential_spec.rb
@@ -4,14 +4,21 @@ describe "Credential" do
   let(:token) { "fake_token" }
   let(:credential) { Credential.new(token) }
 
-  describe "logged_in?", :focus do
+  before do
+    # override the client env to ensure there is a signing key for decoding
+    allow(credential)
+    .to receive(:panoptes_client_env)
+    .and_return("production")
+  end
+
+  describe "logged_in?" do
     before do
-      allow(Panoptes::Client).to receive(:new).and_return(jwt_payload)
+      allow(JWT).to receive(:decode).and_return(payload)
     end
 
     context "with a valid token" do
-      let(:jwt_payload) do
-        double(current_user: { 'login' => 'test-user' })
+      let(:payload) do
+        { 'data' => { 'login' => 'test-user' } }
       end
 
       it "should pass" do
@@ -20,8 +27,8 @@ describe "Credential" do
     end
 
     context "with a token missing the login attribute" do
-      let(:jwt_payload) do
-        double(current_user: { 'id' => 1 })
+      let(:payload) do
+        { 'data' => { 'id' => 1 } }
       end
 
       it "should fail" do
@@ -31,12 +38,39 @@ describe "Credential" do
   end
 
   describe "expired?" do
-    it "should pass with a valid token" do
-      pending
+    before do
+      allow(JWT).to receive(:decode).and_return(payload)
     end
 
-    it "should fail when token has expired" do
-      pending
+    context "with a non expired token" do
+      let(:one_minute) { 60 }
+      let(:payload) do
+        { 'exp' => (Time.now + one_minute).utc.to_i }
+      end
+
+      it "should be false" do
+        expect(credential.expired?).to eq(false)
+      end
+    end
+
+    context "with a non expired token" do
+      let(:three_hours) { 3 * 60 * 60 }
+      let(:payload) do
+        { 'exp' => (Time.now - three_hours).utc.to_i }
+      end
+
+      it "should be true" do
+        expect(credential.expired?).to eq(true)
+      end
+    end
+
+    context "with a token that can't be decoded" do
+      let(:payload) { {} }
+
+      it "should be true" do
+        allow(JWT).to receive(:decode).and_raise(JWT::ExpiredSignature)
+        expect(credential.expired?).to eq(true)
+      end
     end
   end
 

--- a/spec/lib/credential_spec.rb
+++ b/spec/lib/credential_spec.rb
@@ -1,13 +1,32 @@
 require 'spec_helper.rb'
 
-describe "Credential", :focus do
-  describe "logged_in?" do
-    it "should pass" do
-      pending
+describe "Credential" do
+  let(:token) { "fake_token" }
+  let(:credential) { Credential.new(token) }
+
+  describe "logged_in?", :focus do
+    before do
+      allow(Panoptes::Client).to receive(:new).and_return(jwt_payload)
     end
 
-    it "should fail when missing a user-id" do
-      pending
+    context "with a valid token" do
+      let(:jwt_payload) do
+        double(current_user: { 'login' => 'test-user' })
+      end
+
+      it "should pass" do
+        expect(credential.logged_in?).to eq(true)
+      end
+    end
+
+    context "with a token missing the login attribute" do
+      let(:jwt_payload) do
+        double(current_user: { 'id' => 1 })
+      end
+
+      it "should fail" do
+        expect(credential.logged_in?).to eq(false)
+      end
     end
   end
 

--- a/spec/lib/credential_spec.rb
+++ b/spec/lib/credential_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper.rb'
+
+describe "Credential", :focus do
+  describe "logged_in?" do
+    it "should pass" do
+      pending
+    end
+
+    it "should fail when missing a user-id" do
+      pending
+    end
+  end
+
+  describe "expired?" do
+    it "should pass with a valid token" do
+      pending
+    end
+
+    it "should fail when token has expired" do
+      pending
+    end
+  end
+
+  describe "accessible_project?" do
+    it "should pass with correct roles for token" do
+      pending
+    end
+
+    it "should fail when i have no roles on project" do
+      pending
+    end
+  end
+end


### PR DESCRIPTION
add specs on the credential code (long term these should move to a gem) and refactor how the credential code works, specifically: 
- decoding the JWT token
- optimize the project lookup through the zooniverse API
- add better messaging when the token in invalid