### PR TITLE
Add traceable UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,37 @@ All of the APIs exposed by this gateway service require you to pass in a
 project ID.  If the project ID given does not match a project that you are an
 owner or collaborator on, you will get an HTTP 403 error status.
 
+The system will respond with a JSON payload outlining the state of the incoming request.
+
+On Error you will receive a JSON object with a list of errors
+
+```json
+{
+    "errors: [
+        "requires message, project_id and user_id attributes"
+    ]
+}
+```
+
+On Success you will receive a JSON object outlining the state of the request and a unique identifier (uuid) that will be tracked in any associated classification metadata resulting from the request.
+
+```json
+{
+    "status": "ok",
+    "message": "payload sent to user_id: 6",
+    "uuid": "2d931510-d99f-494a-8c67-87feb05e1594"
+}
+```
+
 This service exposes the following API endpoints:
 
 ### `POST /messages`
 
 This lets you send a message to a user, if they are currently online.
 
-A message will be shown to the user once they submit the classification they are currently working on.
+A message will be shown to the specified user once they submit the classification they are currently working on.
 
-A message will not be shown after posting to this message API if the user never submits another classification or they reload / close their browser.
+A message will not be shown to the specified user after posting to this message API if the user never submits another classification or they reload / close their browser.
 
 ```json
 {
@@ -46,6 +68,7 @@ A message will not be shown after posting to this message API if the user never 
     "message": "All of your contributions really help."
 }
 ```
+
 
 **Please note: the behaviour of how the interventions events are presented to the user is out of the control of this repo.** Please refer to  https://github.com/zooniverse/Panoptes-Front-End/ for specific details on intervention message handling.
 

--- a/interventions_gateway_api.rb
+++ b/interventions_gateway_api.rb
@@ -111,20 +111,20 @@ class InterventionsGatewayApi < Sinatra::Base
     credential.logged_in? && !credential.expired?
   end
 
-  def authorize(request)
-    if credential.accessible_project?(request.project_id)
+  def authorize(message)
+    if credential.accessible_project?(message.project_id)
       yield
-      success_response(request.user_id)
+      success_response(message.user_id, message.uuid)
     else
       error_response(403, 'You do not have access to this project')
     end
   end
 
-  def success_response(user_id)
+  def success_response(user_id, uuid)
     {
       status: "ok",
       message: "payload sent to user_id: #{user_id}",
-      uuid: SecureRandom.uuid
+      uuid: uuid
     }.to_json
   end
 
@@ -134,7 +134,10 @@ class InterventionsGatewayApi < Sinatra::Base
 
   class Intervention < OpenStruct
     def initialize(params)
-      super(params.merge(INTERVENTION_EVENT))
+      uuid_added = params.merge(uuid: SecureRandom.uuid)
+      full_payload = uuid_added.merge(INTERVENTION_EVENT)
+
+      super(full_payload)
     end
   end
 

--- a/interventions_gateway_api.rb
+++ b/interventions_gateway_api.rb
@@ -45,7 +45,10 @@ class InterventionsGatewayApi < Sinatra::Base
     valid_payload = SORTED_MESSAGE_KEYS == json.keys.sort
 
     unless valid_payload
-      halt 422, 'message requires message, project_id and user_id attributes'
+      error_response(
+        422,
+        'message requires message, project_id and user_id attributes'
+      )
     end
 
     message = Message.new(json)
@@ -120,8 +123,13 @@ class InterventionsGatewayApi < Sinatra::Base
   def success_response(user_id)
     {
       status: "ok",
-      message: "payload sent to user_id: #{user_id}"
+      message: "payload sent to user_id: #{user_id}",
+      uuid: SecureRandom.uuid
     }.to_json
+  end
+
+  def error_response(status_code, message)
+    halt status_code, { errors: [message] }.to_json
   end
 
   class Intervention < OpenStruct

--- a/interventions_gateway_api.rb
+++ b/interventions_gateway_api.rb
@@ -29,7 +29,7 @@ class InterventionsGatewayApi < Sinatra::Base
     if request.post?
       setup_credentials
       unless valid_credentials
-        halt 401, 'invalid credentials, please check your token details'
+        error_response(401, 'invalid credentials, please check your token details')
       end
     end
   end
@@ -70,7 +70,7 @@ class InterventionsGatewayApi < Sinatra::Base
     valid_payload = SORTED_SUBJECT_QUEUE_KEYS == json.keys.sort
 
     unless valid_payload
-      halt 422, 'subject_queues requires project_id, subject_ids, user_id and workflow_id attributes'
+      error_response(422, 'subject_queues requires project_id, subject_ids, user_id and workflow_id attributes')
     end
 
     subject_queue_req = SubjectQueue.new(json)
@@ -116,7 +116,7 @@ class InterventionsGatewayApi < Sinatra::Base
       yield
       success_response(request.user_id)
     else
-      halt 403, 'You do not have access to this project'
+      error_response(403, 'You do not have access to this project')
     end
   end
 

--- a/spec/interventions_api_gateway_spec.rb
+++ b/spec/interventions_api_gateway_spec.rb
@@ -52,15 +52,18 @@ describe "InterventionsGatewayApi" do
     let(:credential) { instance_double(Credential, expired?: false, logged_in?: true) }
     let(:sugar) { instance_double(Sugar) }
     let(:project_id) { "3434" }
+    let(:uuid) { SecureRandom.uuid }
 
     before do
+      uuid
       allow(Credential).to receive(:new).and_return(credential)
       allow(Sugar).to receive(:new).and_return(sugar)
     end
 
     def sugar_intervention_payload(payload)
       payload.merge({
-        event: 'intervention'
+        event: 'intervention',
+        uuid: uuid
       })
     end
 
@@ -123,7 +126,6 @@ describe "InterventionsGatewayApi" do
         end
 
         it "should respond with a success message" do
-          uuid = SecureRandom.uuid
           allow(sugar).to receive(:experiment)
           allow(SecureRandom).to receive(:uuid).and_return(uuid)
           post '/subject_queues', json_payload, headers
@@ -137,6 +139,7 @@ describe "InterventionsGatewayApi" do
         end
 
         it "should forward the request to sugar client" do
+          allow(SecureRandom).to receive(:uuid).and_return(uuid)
           sugar_payload = sugar_intervention_payload(
             payload.merge(event_type: 'subject_queue')
           )
@@ -206,6 +209,7 @@ describe "InterventionsGatewayApi" do
         end
 
         it "should forward the request to sugar client" do
+          allow(SecureRandom).to receive(:uuid).and_return(uuid)
           sugar_payload = sugar_intervention_payload(
             payload.merge(event_type: 'message')
           )

--- a/spec/interventions_api_gateway_spec.rb
+++ b/spec/interventions_api_gateway_spec.rb
@@ -119,12 +119,15 @@ describe "InterventionsGatewayApi" do
         end
 
         it "should respond with a success message" do
+          uuid = SecureRandom.uuid
           allow(sugar).to receive(:experiment)
+          allow(SecureRandom).to receive(:uuid).and_return(uuid)
           post '/subject_queues', json_payload, headers
           json_response_body = JSON.parse(last_response.body)
           expected_msg = {
             "status"=>"ok",
-            "message"=>"payload sent to user_id: 23"
+            "message"=>"payload sent to user_id: 23",
+            "uuid"=>uuid
           }
           expect(json_response_body).to eq(expected_msg)
         end
@@ -156,6 +159,11 @@ describe "InterventionsGatewayApi" do
       it "should respond with unprocessable with extra payload information" do
         post '/messages', payload.merge(not_needed: "true").to_json, headers
         expect(last_response).to be_unprocessable
+        json_response_body = JSON.parse(last_response.body)
+        expected_msg = {
+          "errors" => ["message requires message, project_id and user_id attributes"]
+        }
+        expect(json_response_body).to eq(expected_msg)
       end
 
       %i(project_id message user_id).each do |attribute|

--- a/spec/interventions_api_gateway_spec.rb
+++ b/spec/interventions_api_gateway_spec.rb
@@ -18,7 +18,11 @@ describe "InterventionsGatewayApi" do
     it "should respond with unauthorized without auth headers" do
       post end_point, json_payload
       expect(last_response).to be_unauthorized
-      expect(last_response.body).to eq("invalid credentials, please check your token details")
+      json_response_body = JSON.parse(last_response.body)
+      error_response = {
+        "errors" => ["invalid credentials, please check your token details"]
+      }
+      expect(json_response_body).to eq(error_response)
     end
 
     context "when token is expired" do


### PR DESCRIPTION
closes #28 - Add a UUID to be sent with the message to downstream sugar clients and the api response object. The UUID should be linked to any downstream classification data after an intervention event has occurred.