### PR TITLE
use the raise_error middleware

### DIFF
--- a/lib/sugar.rb
+++ b/lib/sugar.rb
@@ -27,6 +27,7 @@ class Sugar
 
   def connection
     @connection ||= Faraday.new(host) do |faraday|
+      faraday.use Faraday::Response::RaiseError
       faraday.response :json, content_type: /\bjson$/
       faraday.basic_auth username, password
       faraday.adapter Faraday.default_adapter


### PR DESCRIPTION
do not silently swallow HTTP errors for requests to the sugar services