### PR TITLE
Action: Staging deploy

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,0 +1,43 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build_and_push_image:
+    name: Build and Push Image
+    uses: zooniverse/ci-cd/.github/workflows/build_and_push_image.yaml@optional-build-args
+    with:
+      repo_name: interventions-gateway
+      commit_id: ${{ github.sha }}
+      latest: true
+      build-args: "REVISION=${{ github.sha }}"
+
+  deploy_staging:
+    name: Deploy to Staging
+    uses: zooniverse/ci-cd/.github/workflows/deploy_app.yaml@main
+    needs: build_and_push_image
+    with:
+      app_name: interventions-gateway
+      repo_name: interventions-gateway
+      commit_id: ${{ github.sha }}
+      environment: staging
+    secrets:
+      creds: ${{ secrets.AZURE_AKS }}
+
+  slack_notification:
+    name: Slack notification
+    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
+    needs: deploy_staging
+    if: always()
+    with:
+      commit_id: ${{ github.sha }}
+      job_name: Deploy to Staging / deploy_app
+      status: ${{ needs.deploy_staging.result }}
+      title: "interventions-gateway Staging deploy & migration complete"
+      title_link: "https://caesar-staging.zooniverse.org"
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_and_push_image:
     name: Build and Push Image
-    uses: zooniverse/ci-cd/.github/workflows/build_and_push_image.yaml@optional-build-args
+    uses: zooniverse/ci-cd/.github/workflows/build_and_push_image.yaml@main
     with:
       repo_name: interventions-gateway
       commit_id: ${{ github.sha }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,14 +27,6 @@ pipeline {
       }
     }
 
-    stage('Deploy staging to Kubernetes') {
-      when { branch 'master' }
-      agent any
-      steps {
-        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-staging.tmpl | kubectl --context azure apply --record -f -"
-      }
-    }
-
     stage('Deploy production to Kubernetes') {
       when { tag 'production-release' }
       agent any

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: interventions-gateway
-          image: zooniverse/interventions-gateway:__IMAGE_TAG__
+          image: ghcr.io/zooniverse/interventions-gateway:__IMAGE_TAG__
           imagePullPolicy: Always
           resources:
                 requests:


### PR DESCRIPTION
Adds an action that uses the shared build/push & deploy workflows for staging, and updates the Jenkinsfile to remove staging deploy.

Trying something slightly different with the build here: I updated the ci-cd build/push workflow to receive optional build-args (see https://github.com/zooniverse/ci-cd/pull/22 & https://github.com/zooniverse/aggregation-for-caesar/pull/548). This will allow the "in the Dockerfile, use ENV to lock in an ephemeral build-arg" trick to continue to work and obviates the need to create the env var in an app script somewhere.

Not sure if this is better yet, so I'm going to confirm it works and them make the call.