### PR TITLE
Fix typo in build/push step

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -14,7 +14,7 @@ jobs:
       repo_name: interventions-gateway
       commit_id: ${{ github.sha }}
       latest: true
-      build-args: "REVISION=${{ github.sha }}"
+      build_args: "REVISION=${{ github.sha }}"
 
   deploy_staging:
     name: Deploy to Staging


### PR DESCRIPTION
Keeping track of `_` vs `-` is a pain but I think it's better to leave all the `with:` arguments the same.